### PR TITLE
Fix gulpfile compile tasks and their order.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,8 +42,8 @@ gulp.task('transformScripts', function() {
     .pipe(gulp.dest('dist/'));
 });
 
-gulp.task('compileScripts', ['transformScripts'], function() {
-  return compileScriptsFromEntryPoint('./dist/App.js', 'boomstrap-react.js', 'dist/');
+gulp.task('compileScripts', function() {
+  return compileScriptsFromEntryPoint('./src/App.js', 'boomstrap-react.js', 'dist/');
 });
 
 gulp.task('compileDocsScripts', function(callback) {


### PR DESCRIPTION
It was:
`ES6 src` => `babel-transpiler` => `ES5 dist/*.*` => `babel-transpiler` => `ES5 dist/boomstrap-react.js`

I.e. `ES5` => `boomstrap-react.js` => `ES5` was wrong I presume.