### PR TITLE
Eslint and peerDependencies warnings.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 gulpfile.js
 webpack.website.config.js
 website
+www
 dist
 docs
 __tests__

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,6 @@
 gulpfile.js
-website/examples/**/*.*
+webpack.website.config.js
+website
+dist
+docs
+__tests__

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "browserify-global-shim": "^1.0.0",
     "component-playground": "0.0.10",
     "css-loader": "^0.12.0",
-    "eslint": "^0.20.0",
+    "eslint": "^0.22.1",
     "eslint-plugin-react": "^2.1.1",
     "gulp": "^3.8.10",
     "gulp-babel": "^4.0.0",
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "test": "jest",
-    "lint": "eslint -c .eslintrc --ext .js --ext .jsx src/.",
+    "lint": "eslint .",
     "docs": "react-docgen dist/Components/ --pretty --o ./docs/docs.json"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "devDependencies": {
     "autoprefixer-loader": "^1.2.0",
+    "babel-core": "^5.5.4",
     "babel-eslint": "^3.0.0",
     "babel-jest": "^4.0.0",
     "babel-loader": "^5.1.3",
@@ -33,6 +34,7 @@
     "less": "^2.5.0",
     "less-loader": "^2.2.0",
     "marked": "^0.3.2",
+    "node-libs-browser": "^0.5.2",
     "raw-loader": "^0.5.1",
     "react-docgen": "^1.2.0",
     "react-router": "^0.13.3",
@@ -51,7 +53,7 @@
   },
   "scripts": {
     "test": "jest",
-    "lint": "eslint .",
+    "lint": "eslint --ext .js --ext .jsx .",
     "docs": "react-docgen dist/Components/ --pretty --o ./docs/docs.json"
   },
   "jest": {


### PR DESCRIPTION
There is already `.eslintignore` file exist, so just use it fo full blacklisting
instead of whitelisting in config parameters `eslint -c .eslintrc --ext .js --ext .jsx src/.`

And fix for npm warnings
```
The peer dependency babel-core@* included from babel-loader will no
The peer dependency node-libs-browser@>= 0.4.0 <=0.6.0 included from webpack will no
```