### PR TITLE
Use .babelrc for babel-loader with webpack.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "optional": [
+    "es7.objectRestSpread"
+  ]
+}

--- a/webpack.website.config.js
+++ b/webpack.website.config.js
@@ -18,10 +18,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: [/node_modules/, /examples/],
-        loader: 'babel-loader',
-        query: {
-          optional: ['es7.objectRestSpread']
-        }
+        loader: 'babel-loader'
       },
       { test: /\.less$/, loader: 'style-loader!css-loader!less-loader!autoprefixer-loader?{browsers:["last 2 version", "IE 9"]}'}
     ]


### PR DESCRIPTION
When babel used with webpack through `babel-loader`,
it can get it options as `babel` does from `.babelrc` file.

Alas `babelify` and `gulp-babel` packages doesn't get their options from this file.

If you switch from usage `browserify`+ `babelify` and `gulp-babel`
to `webpack` + `babel-loader` as you already do it for website,
then you can get rid of a lot of code in `gulpfile.js` :wink: 

Hence you will DRY
[gulpfile.js#L26](https://github.com/BoomTownROI/boomstrap-react/blob/f3ffd84cad732abc6e42833d3db1abe10a798b2b/gulpfile.js#L26) `optional: ['es7.objectRestSpread']`
[gulpfile.js#L40](https://github.com/BoomTownROI/boomstrap-react/blob/f3ffd84cad732abc6e42833d3db1abe10a798b2b/gulpfile.js#L40) `optional: ['es7.objectRestSpread']`
[webpack.website.config.js#L23](https://github.com/BoomTownROI/boomstrap-react/blob/31cc37f8926fc10cbee4ea4ea398092222309f6a/webpack.website.config.js#L23) `optional: ['es7.objectRestSpread']`