### PR TITLE
Use babel and npm for build process.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "devDependencies": {
     "autoprefixer-loader": "^1.2.0",
+    "babel": "^5.5.4",
     "babel-core": "^5.5.4",
     "babel-eslint": "^3.0.0",
     "babel-jest": "^4.0.0",
@@ -54,7 +55,8 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint --ext .js --ext .jsx .",
-    "docs": "react-docgen dist/Components/ --pretty --o ./docs/docs.json"
+    "docs": "react-docgen dist/Components/ --pretty --o ./docs/docs.json",
+    "build": "babel src --out-dir dist"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",


### PR DESCRIPTION
https://github.com/BoomTownROI/boomstrap-react/pull/11#issuecomment-109621964
> We actually don't even use the distributable in our stuff, just the CommonJS output. We still need gulp-babel though to transform individual modules as far as I can tell.

`babel src --out-dir dist` will do such transformation of individual modules
and it will have nice side effect,
there will be only `*.js` files in `dist/` folder.

As for now it is a bit weird that transpiled files in `dist` folder have `.jsx` extension.
`.jsx` implies that file contains `jsx` syntax :wink: 

It will use `.babelrc` and you can put it as script into `package.json` as
```js
"scripts": {
  ...
  "build": "babel src --out-dir dist"
},
```

I hope it is what you meant :cherries: 