### PR TITLE
Use React.PropTypes.node as type for children property.

### DIFF
--- a/src/Components/Callout.jsx
+++ b/src/Components/Callout.jsx
@@ -11,7 +11,7 @@ module.exports = React.createClass({
     /**
      * Optionally include children.
      */
-    children: React.PropTypes.any,
+    children:   React.PropTypes.node,
     /**
      * Optionally include additional class name(s).
      */
@@ -28,24 +28,16 @@ module.exports = React.createClass({
 
   getDefaultProps() {
     return {
-      type:       'info'
+      type: 'info'
     };
   },
 
   render() {
     const classes = cx('callout', 'callout-' + this.props.type, this.props.className);
 
-    let calloutHeading = null;
-
-    if (this.props.heading) {
-      calloutHeading = (
-        <h4>{this.props.heading}</h4>
-      );
-    }
-
     return (
       <div className={classes}>
-        {calloutHeading}
+        {this.props.heading ? <h4>{this.props.heading}</h4> : null}
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
And small aesthetical strokes.

--
from https://facebook.github.io/react/docs/reusable-components.html
> React.PropTypes.node
// Anything that can be rendered: numbers, strings, elements or an array
// containing these types.

and https://github.com/yannickcr/eslint-plugin-react/issues/7#issuecomment-106949101