### PR TITLE
Use propTypes check in Mixin

### DIFF
--- a/src/Mixins/DocumentClickMixin.jsx
+++ b/src/Mixins/DocumentClickMixin.jsx
@@ -26,6 +26,9 @@ function isNodeInRoot(node, root) {
 }
 
 module.exports = {
+  propTypes: {
+    onDocumentClick: React.PropTypes.func.isRequired
+  },
 
   handleDocumentKeyUp: function(e) {
     if (e.keyCode === 27) {
@@ -43,20 +46,12 @@ module.exports = {
   },
 
   componentDidMount: function() {
-    if (this.onDocumentClick) {
-      document.addEventListener('click', this.handleDocumentClick, false);
-      document.addEventListener('keyup', this.handleDocumentKeyUp, false);
-    } else if (console && console.warn) {
-      console.warn('Please provide the function `onDocumentClick` to your Component');
-    }
+    document.addEventListener('click', this.handleDocumentClick, false);
+    document.addEventListener('keyup', this.handleDocumentKeyUp, false);
   },
 
   componentWillUnmount: function() {
-    if (this.onDocumentClick) {
-      document.removeEventListener('click', this.handleDocumentClick, false);
-      document.removeEventListener('keyup', this.handleDocumentKeyUp, false);
-    } else if (console && console.warn) {
-      console.warn('Please provide the function `onDocumentClick` to your Component');
-    }
+    document.removeEventListener('click', this.handleDocumentClick, false);
+    document.removeEventListener('keyup', this.handleDocumentKeyUp, false);
   }
 };


### PR DESCRIPTION
Now warning looks like:
```
Warning: Failed propType: Required prop `onDocumentClick` was not specified in `UI Select Dropdown Menu`.
```
if `onDocumentClick` is ommitted in `UI Select Dropdown Menu` component.