### PR TITLE
Add examples for UISelect component. Remove extraneous code.

### DIFF
--- a/src/Components/UISelect.jsx
+++ b/src/Components/UISelect.jsx
@@ -11,7 +11,7 @@ const UISelectDropdownMenu = React.createClass({
   propTypes: {
     className: React.PropTypes.string,
     onClose:   React.PropTypes.func,
-    children:  React.PropTypes.any
+    children:  React.PropTypes.node
   },
 
   mixins: [DocumentClickMixin],
@@ -87,8 +87,8 @@ module.exports = React.createClass({
     return {
       items: [],
       disabled: false,
-      alignRight: false,
-      containerClass: ''
+      containerClass: '',
+      alignRight: false
     };
   },
 
@@ -246,7 +246,12 @@ module.exports = React.createClass({
     if (!this.state.open) {
       elementClass = cx('btn btn-default form-control ui-select-match', this.props.buttonClass);
       showElement  = (
-        <button className={elementClass} disabled={this.props.disabled} onClick={this.activate} placeholder={this.props.placeholder} tabIndex='-1' type='button'>
+        <button
+          className={elementClass}
+          disabled={this.props.disabled}
+          onClick={this.activate}
+          tabIndex='-1'
+          type='button'>
           {isEmpty ?  (<span className='text-muted'>{this.props.placeholder}</span>) : (<span>{this.props.text}</span>) }
           <span className='caret'></span>
         </button>

--- a/website/examples/UISelect.example.js
+++ b/website/examples/UISelect.example.js
@@ -1,4 +1,4 @@
-var CompnentExample = React.createClass({
+var ComponentExample = React.createClass({
   render() {
     let list = [
       {text: 'One', payload: 1},
@@ -10,9 +10,19 @@ var CompnentExample = React.createClass({
     return (
       <div>
         <h4>UISelect</h4>
-        <UISelect items={list} text={this.state.text} onChange={this.onChange} />
+        <UISelect buttonClass='btn-success' items={list} text={this.state.text} onChange={this.onChange} />
         <br />
         <UISelect buttonClass='btn-danger' items={list} text={this.state.text} onChange={this.onChange} />
+        <br />
+        <UISelect disabled buttonClass='btn-primary' text='Disabled state' />
+        <br />
+        <UISelect
+          items={list}
+          text={this.state.textInfo}
+          placeholder='Placeholder text'
+          onChange={this.onChange} />
+        {/* For examples page usability. Prevents a need of scrolling. */}
+        <div style={{'marginBottom': 100}} />
       </div>
     );
   },
@@ -27,9 +37,10 @@ var CompnentExample = React.createClass({
     let { text, payload } = selection;
 
     this.setState({
-      text: `You chose ${text}; which has a payload of ${payload}`
+      text: `You chose ${text}; which has a payload of ${payload}`,
+      textInfo: `Text for placeholder example. ${text} - ${payload}`
     });
   }
 });
 
-React.render(<CompnentExample />, mountNode)
+React.render(<ComponentExample />, mountNode)


### PR DESCRIPTION
Use `React.PropTypes.node` for children.

Remove `placeholder={this.props.placeholder}` from `<button ..>`

Fix `CompnentExample` => `ComponentExample`

Add margin at the bottom of examples page for usability.

Add two additional examples:
`disabled` state and
`placeholder` usage

`containerClass: ''` isn't required
because `classnames` correctly ignores `undefined` and `null` values
https://github.com/JedWatson/classnames
> // other falsy values are just ignored
classNames(null, false, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'

![screen shot 2015-06-07 at 9 40 23 pm](https://cloud.githubusercontent.com/assets/847572/8025400/005696ca-0d5e-11e5-917b-a0daac053bbd.png)
