### PR TITLE
Leadcats, Lead Types and Lead Category By Type

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -758,34 +758,23 @@
           "computed": false
         }
       },
-      "equal": {
+      "square": {
         "type": {
           "name": "bool"
         },
         "required": false,
-        "description": "For equal width lead type labels, set equal to true.",
+        "description": "For square (and stacked b/s) lead type labels, set square to true.",
         "defaultValue": {
           "value": "false",
           "computed": false
         }
       },
-      "abbreviated": {
+      "small": {
         "type": {
           "name": "bool"
         },
         "required": false,
-        "description": "For abbreviated lead type labels, set abbreviated to true.\nAbbreviated version will always be uppercase.",
-        "defaultValue": {
-          "value": "false",
-          "computed": false
-        }
-      },
-      "vertical": {
-        "type": {
-          "name": "bool"
-        },
-        "required": false,
-        "description": "Sometimes you just want to stand things on their heads.\nSet vertical and abbreviated to true when you need your leadtype to reach for the stars.\nThis only applies to the B/S combination.",
+        "description": "Small augments square and produces leadtype-square-sm.\nSmall by itself does nothing.",
         "defaultValue": {
           "value": "false",
           "computed": false

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -687,50 +687,6 @@
         "required": true,
         "description": ""
       },
-      "equal": {
-        "type": {
-          "name": "bool"
-        },
-        "required": false,
-        "description": "",
-        "defaultValue": {
-          "value": "false",
-          "computed": false
-        }
-      },
-      "abbreviated": {
-        "type": {
-          "name": "bool"
-        },
-        "required": false,
-        "description": "",
-        "defaultValue": {
-          "value": "false",
-          "computed": false
-        }
-      },
-      "small": {
-        "type": {
-          "name": "bool"
-        },
-        "required": false,
-        "description": "",
-        "defaultValue": {
-          "value": "false",
-          "computed": false
-        }
-      },
-      "outline": {
-        "type": {
-          "name": "bool"
-        },
-        "required": false,
-        "description": "",
-        "defaultValue": {
-          "value": "false",
-          "computed": false
-        }
-      },
       "muted": {
         "type": {
           "name": "bool"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -714,7 +714,30 @@
   "dist/Components/LeadCategoryByType.js": {
     "description": "",
     "props": {
+      "className": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": ""
+      },
+      "buyer": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "Indicates whether or not this is a buyer category",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
       "seller": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "Indicates whether or not this is a seller category",
         "defaultValue": {
           "value": "false",
           "computed": false

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -714,30 +714,13 @@
   "dist/Components/LeadCategoryByType.js": {
     "description": "",
     "props": {
-      "className": {
-        "type": {
-          "name": "string"
-        },
-        "required": false,
-        "description": ""
-      },
       "buyer": {
-        "type": {
-          "name": "bool"
-        },
-        "required": false,
-        "description": "Indicates whether or not this is a buyer category",
         "defaultValue": {
           "value": "false",
           "computed": false
         }
       },
       "seller": {
-        "type": {
-          "name": "bool"
-        },
-        "required": false,
-        "description": "Indicates whether or not this is a seller category",
         "defaultValue": {
           "value": "false",
           "computed": false

--- a/src/Components/LeadCategory.jsx
+++ b/src/Components/LeadCategory.jsx
@@ -17,10 +17,6 @@ module.exports = React.createClass({
 
   propTypes: {
     category:    React.PropTypes.number.isRequired,
-    equal:       React.PropTypes.bool,
-    abbreviated: React.PropTypes.bool,
-    small:       React.PropTypes.bool,
-    outline:     React.PropTypes.bool,
     muted:       React.PropTypes.bool,
     disabled:    React.PropTypes.bool
   },
@@ -29,10 +25,6 @@ module.exports = React.createClass({
 
   getDefaultProps() {
     return {
-      equal:       false,
-      abbreviated: false,
-      small:       false,
-      outline:     false,
       muted:       false,
       disabled:    false
     };
@@ -40,10 +32,6 @@ module.exports = React.createClass({
 
   render: function() {
     const {
-      equal,
-      abbreviated,
-      small,
-      outline,
       muted,
       disabled,
       ...props
@@ -54,17 +42,13 @@ module.exports = React.createClass({
 
     const categoryClass = 'leadcat-' + category.toLowerCase();
     const catClass = cx(categoryClass, 'leadcat', {
-      'leadcat-eq-abbr':    equal && abbreviated && !small,
-      'leadcat-eq-abbr-sm': equal && abbreviated && small,
-      'leadcat-eq':         equal && !abbreviated,
-      'leadcat-outline':    outline,
       'leadcat-muted':      muted,
       'leadcat-disabled':   disabled
     });
 
     return (
       <span {...props} className={catClass}>
-        { abbreviated ? abbr : category }
+        { abbr }
       </span>
     );
   }

--- a/src/Components/LeadCategoryByType.jsx
+++ b/src/Components/LeadCategoryByType.jsx
@@ -8,20 +8,25 @@ module.exports = React.createClass({
   displayName: 'LeadCategoryByType',
 
   propTypes: {
+    ...LeadCategory.propTypes,
     className: React.PropTypes.string,
+
+    /**
+     * Indicates whether or not this is a buyer category
+     */
+    buyer: React.PropTypes.bool,
 
     /**
      * Indicates whether or not this is a seller category
      */
     seller: React.PropTypes.bool,
-
-    ...LeadCategory.propTypes
   },
 
   mixins: [PureRenderMixin],
 
   getDefaultProps() {
     return {
+      buyer:  false,
       seller: false
     };
   },
@@ -33,6 +38,10 @@ module.exports = React.createClass({
       className,
       ...props
     } = this.props;
+
+    if (!buyer && !seller) {
+      return null;
+    }
 
     return (
       <span className={className}>
@@ -54,3 +63,4 @@ module.exports = React.createClass({
     );
   }
 });
+

--- a/src/Components/LeadCategoryByType.jsx
+++ b/src/Components/LeadCategoryByType.jsx
@@ -28,6 +28,7 @@ module.exports = React.createClass({
 
   render: function() {
     const {
+      buyer,
       seller,
       className,
       ...props
@@ -36,7 +37,7 @@ module.exports = React.createClass({
     return (
       <span className={className}>
         <LeadType
-          buyer={!seller}
+          buyer={buyer}
           seller={seller}
           abbreviated
           style={{

--- a/src/Components/LeadCategoryByType.jsx
+++ b/src/Components/LeadCategoryByType.jsx
@@ -8,7 +8,6 @@ module.exports = React.createClass({
   displayName: 'LeadCategoryByType',
 
   propTypes: {
-    ...LeadCategory.propTypes,
     className: React.PropTypes.string,
 
     /**
@@ -20,6 +19,7 @@ module.exports = React.createClass({
      * Indicates whether or not this is a seller category
      */
     seller: React.PropTypes.bool,
+    ...LeadCategory.propTypes
   },
 
   mixins: [PureRenderMixin],

--- a/src/Components/LeadType.jsx
+++ b/src/Components/LeadType.jsx
@@ -20,34 +20,26 @@ module.exports = React.createClass({
     seller:      PropTypes.bool,
 
     /**
-     * For equal width lead type labels, set equal to true.
+     * For square (and stacked b/s) lead type labels, set square to true.
      */
-    equal:       PropTypes.bool,
+    square:      PropTypes.bool,
 
     /**
-     * For abbreviated lead type labels, set abbreviated to true.
-     * Abbreviated version will always be uppercase.
+     * Small augments square and produces leadtype-square-sm.
+     * Small by itself does nothing.
      */
-    abbreviated: PropTypes.bool,
-
-    /**
-     * Sometimes you just want to stand things on their heads.
-     * Set vertical and abbreviated to true when you need your leadtype to reach for the stars.
-     * This only applies to the B/S combination.
-     */
-    vertical:    PropTypes.bool
+    small:       PropTypes.bool
   },
 
   mixins: [addons.PureRenderMixin],
 
   getDefaultProps() {
     return {
-      className: '',
-      buyer: false,
-      seller: false,
-      equal: false,
-      abbreviated: false,
-      vertical: false
+      className:    '',
+      buyer:        false,
+      seller:       false,
+      square:       false,
+      small:        false
     };
   },
 
@@ -55,9 +47,8 @@ module.exports = React.createClass({
     const {
       buyer,
       seller,
-      equal,
-      abbreviated,
-      vertical,
+      square,
+      small,
       ...props
     } = this.props;
 
@@ -65,9 +56,8 @@ module.exports = React.createClass({
       'leadtype-buyer':         buyer && !seller,
       'leadtype-seller':       !buyer &&  seller,
       'leadtype-bs':            buyer &&  seller,
-      'leadtype-eq':            equal,
-      'leadtype-abbr':          abbreviated,
-      'leadtype-abbr-vertical': abbreviated && vertical
+      'leadtype-square':        square,
+      'leadtype-square-sm':     square && small
     });
 
     return (

--- a/website/examples/LeadCategory.example.js
+++ b/website/examples/LeadCategory.example.js
@@ -2,16 +2,42 @@ var ComponentExample = React.createClass({
   render() {
     return (
       <div>
-        <h4>Lead Category</h4>
-        <LeadCategory category={0}/>&nbsp;
-        <LeadCategory category={1}/>&nbsp;
-        <LeadCategory category={2}/>&nbsp;
-        <LeadCategory category={3}/>&nbsp;
-        <LeadCategory category={4}/>&nbsp;
-        <LeadCategory category={5}/>&nbsp;
-        <LeadCategory category={6}/>&nbsp;
-        <LeadCategory category={10}/>&nbsp;
-        <LeadCategory category={11}/>
+        <div>
+          <h4>Lead Category</h4>
+          <LeadCategory category={0}/>&nbsp;
+          <LeadCategory category={1}/>&nbsp;
+          <LeadCategory category={2}/>&nbsp;
+          <LeadCategory category={3}/>&nbsp;
+          <LeadCategory category={4}/>&nbsp;
+          <LeadCategory category={5}/>&nbsp;
+          <LeadCategory category={6}/>&nbsp;
+          <LeadCategory category={10}/>&nbsp;
+          <LeadCategory category={11}/>
+        </div>
+        <div>
+          <h4>Muted</h4>
+          <LeadCategory category={0} muted />&nbsp;
+          <LeadCategory category={1} muted />&nbsp;
+          <LeadCategory category={2} muted />&nbsp;
+          <LeadCategory category={3} muted />&nbsp;
+          <LeadCategory category={4} muted />&nbsp;
+          <LeadCategory category={5} muted />&nbsp;
+          <LeadCategory category={6} muted />&nbsp;
+          <LeadCategory category={10} muted />&nbsp;
+          <LeadCategory category={11} muted />
+        </div>
+        <div>
+          <h4>Disabled</h4>
+          <LeadCategory category={0} disabled />&nbsp;
+          <LeadCategory category={1} disabled />&nbsp;
+          <LeadCategory category={2} disabled />&nbsp;
+          <LeadCategory category={3} disabled />&nbsp;
+          <LeadCategory category={4} disabled />&nbsp;
+          <LeadCategory category={5} disabled />&nbsp;
+          <LeadCategory category={6} disabled />&nbsp;
+          <LeadCategory category={10} disabled />&nbsp;
+          <LeadCategory category={11} disabled />
+        </div>
       </div>
     );
   }

--- a/website/examples/LeadCategoryByType.example.js
+++ b/website/examples/LeadCategoryByType.example.js
@@ -4,15 +4,15 @@ var ComponentExample = React.createClass({
       <div>
         <div>
           <h4>Buyer Lead Category</h4>
-          <LeadCategoryByType category={0}/>&nbsp;
-          <LeadCategoryByType category={1}/>&nbsp;
-          <LeadCategoryByType category={2}/>&nbsp;
-          <LeadCategoryByType category={3}/>&nbsp;
-          <LeadCategoryByType category={4}/>&nbsp;
-          <LeadCategoryByType category={5}/>&nbsp;
-          <LeadCategoryByType category={6}/>&nbsp;
-          <LeadCategoryByType category={10}/>&nbsp;
-          <LeadCategoryByType category={11}/>
+          <LeadCategoryByType buyer category={0}/>&nbsp;
+          <LeadCategoryByType buyer category={1}/>&nbsp;
+          <LeadCategoryByType buyer category={2}/>&nbsp;
+          <LeadCategoryByType buyer category={3}/>&nbsp;
+          <LeadCategoryByType buyer category={4}/>&nbsp;
+          <LeadCategoryByType buyer category={5}/>&nbsp;
+          <LeadCategoryByType buyer category={6}/>&nbsp;
+          <LeadCategoryByType buyer category={10}/>&nbsp;
+          <LeadCategoryByType buyer category={11}/>
         </div>
         <div>
           <h4>Seller Lead Category</h4>
@@ -25,6 +25,18 @@ var ComponentExample = React.createClass({
           <LeadCategoryByType seller category={6}/>&nbsp;
           <LeadCategoryByType seller category={10}/>&nbsp;
           <LeadCategoryByType seller category={11}/>
+        </div>
+        <div>
+          <h4>Buyer/Seller Lead Category</h4>
+          <LeadCategoryByType buyer seller category={0}/>&nbsp;
+          <LeadCategoryByType buyer seller category={1}/>&nbsp;
+          <LeadCategoryByType buyer seller category={2}/>&nbsp;
+          <LeadCategoryByType buyer seller category={3}/>&nbsp;
+          <LeadCategoryByType buyer seller category={4}/>&nbsp;
+          <LeadCategoryByType buyer seller category={5}/>&nbsp;
+          <LeadCategoryByType buyer seller category={6}/>&nbsp;
+          <LeadCategoryByType buyer seller category={10}/>&nbsp;
+          <LeadCategoryByType buyer seller category={11}/>
         </div>
       </div>
     );

--- a/website/examples/LeadType.example.js
+++ b/website/examples/LeadType.example.js
@@ -9,22 +9,16 @@ var ComponentExample = React.createClass({
           <LeadType buyer seller />&nbsp;
         </div>
         <div>
-          <h4>Equal Width</h4>
-          <LeadType buyer equal />&nbsp;
-          <LeadType seller equal />&nbsp;
-          <LeadType buyer seller equal />&nbsp;
+          <h4>Square</h4>
+          <LeadType buyer square />&nbsp;
+          <LeadType seller square />&nbsp;
+          <LeadType buyer seller square />&nbsp;
         </div>
         <div>
-          <h4>Abbreviated</h4>
-          <LeadType buyer abbreviated />&nbsp;
-          <LeadType seller abbreviated />&nbsp;
-          <LeadType buyer seller abbreviated />&nbsp;
-        </div>
-        <div>
-          <h4>Abbreviated Vertical</h4>
-          <LeadType buyer abbreviated vertical />&nbsp;
-          <LeadType seller abbreviated vertical />&nbsp;
-          <LeadType buyer seller abbreviated vertical />&nbsp;
+          <h4>Square Small</h4>
+          <LeadType buyer square small />&nbsp;
+          <LeadType seller square small />&nbsp;
+          <LeadType buyer seller square small />&nbsp;
         </div>
       </div>
     );


### PR DESCRIPTION
Updates to reflect recent changes in Boomstrap and the paring down of optional styles for these components. Updates to the CRM will be required with this merge, particularly with LeadType. The only valid `LeadCategory` variations are `muted` and `disabled`. `LeadType` now only has `square` and `square small` as variants. `LeadCategoryByType` has no alternate styles but now takes `buyer` and `seller` for the B/S combo.